### PR TITLE
Add /fees command to display onchain transaction fees with share option

### DIFF
--- a/src/commands/fees.ts
+++ b/src/commands/fees.ts
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  EmbedBuilder,
+  SlashCommandBuilder,
+  Client,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from "discord.js";
+import { SlashCommand } from "../types";
+import { Debugger } from "debug";
+import { formatAgo, formatPrice, logger } from "../helpers";
+
+const error: Debugger = logger.extend("help").extend("error");
+
+const AVERAGE_TX_SIZE = 140; // vB
+
+const command: SlashCommand = {
+  command: new SlashCommandBuilder()
+    .setName("fees")
+    .setDescription(
+      "Obtiene las tarifas (fees) recomendadas para transacciones onchain."
+    ),
+  execute: async (interaction) => {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+      const client = interaction.client as Client;
+
+      if (!client.fees) {
+        await interaction.editReply("No hay fees disponibles todavía.");
+        return;
+      }
+
+      const author = {
+        name: "Bot BTC",
+        iconURL: "",
+      };
+
+      if (interaction.guild?.members.me?.user.avatarURL()) {
+        author.iconURL = interaction.guild?.members.me?.user.avatarURL() ?? "";
+      }
+
+      const row = new ActionRowBuilder<ButtonBuilder>().addComponents([
+        new ButtonBuilder()
+          .setCustomId("publicar")
+          .setEmoji({ name: `📤` })
+          .setStyle(ButtonStyle.Primary)
+          .setLabel("Publicar fees"),
+      ]);
+
+      const embed = new EmbedBuilder()
+        .setAuthor(author)
+        .setTitle("TASA DE TRANSACCIÓN")
+        .setColor("#f99823")
+        .setDescription(
+          "Fees estimadas actualmente para una transacción onchain de 140 vBytes."
+        )
+        .addFields(
+          {
+            name: "Baja prioridad ⏬",
+            //value: `${fee.fee}\n${fee.usd}`,
+            value: `${client.fees.low} sat/vB\n$${formatPrice(
+              (client.lastPrice * client.fees.low * AVERAGE_TX_SIZE) /
+                100_000_000,
+              true
+            )}`,
+            inline: true,
+          },
+          {
+            name: "Media prioridad ↔️",
+            value: `${client.fees.medium} sat/vB\n$${formatPrice(
+              (client.lastPrice * client.fees.medium * AVERAGE_TX_SIZE) /
+                100_000_000,
+              true
+            )}`,
+            inline: true,
+          },
+          {
+            name: "Alta prioridad ⏫",
+            value: `${client.fees.high} sat/vB\n$${formatPrice(
+              (client.lastPrice * client.fees.high * AVERAGE_TX_SIZE) /
+                100_000_000,
+              true
+            )}`,
+            inline: true,
+          },
+          {
+            name: "Sin prioridad",
+            value: `Si te sentís con suerte, tu fee es ${
+              client.fees.economy
+            } sat/vB ($${formatPrice(
+              (client.lastPrice * client.fees.high * AVERAGE_TX_SIZE) /
+                100_000_000,
+              true
+            )})`,
+            inline: false,
+          }
+        )
+        .setFooter({
+          text: `Actualizado hace ${formatAgo(
+            Date.now() - client.fees.timestamp
+          )}.`,
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed], components: [row] });
+    } catch (err) {
+      error(err);
+      interaction.editReply({ content: "Algo salió mal..." });
+    }
+  },
+};
+
+export default command;

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,8 +1,14 @@
-import { Interaction } from "discord.js";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonComponent,
+  EmbedBuilder,
+  Interaction,
+} from "discord.js";
 import { BotEvent } from "../types";
 
 import { Debugger } from "debug";
-import { logger } from "../helpers";
+import { formatAgo, logger } from "../helpers";
 
 const error: Debugger = logger
   .extend("Event:InteractionCreate")
@@ -15,7 +21,35 @@ const event: BotEvent = {
       const command = interaction.client.slashCommands.get(
         interaction.commandName
       );
+      const cooldown = interaction.client.cooldowns.get(
+        `${interaction.commandName}-${interaction.guildId}-${interaction.user.username}`
+      );
       if (!command) return;
+      if (command.cooldown && cooldown) {
+        if (Date.now() < cooldown) {
+          const wait = formatAgo(Math.abs(Date.now() - cooldown) / 1000);
+
+          interaction.reply(
+            `Tiene que esperar ${wait} para volver a usar este comando.`
+          );
+          setTimeout(() => interaction.deleteReply(), 5000);
+          return;
+        }
+        interaction.client.cooldowns.set(
+          `${interaction.commandName}-${interaction.user.username}`,
+          Date.now() + command.cooldown * 1000
+        );
+        setTimeout(() => {
+          interaction.client.cooldowns.delete(
+            `${interaction.commandName}-${interaction.user.username}`
+          );
+        }, command.cooldown * 1000);
+      } else if (command.cooldown && !cooldown) {
+        interaction.client.cooldowns.set(
+          `${interaction.commandName}-${interaction.guildId}-${interaction.user.username}`,
+          Date.now() + command.cooldown * 1000
+        );
+      }
       command.execute(interaction);
     } else if (interaction.isAutocomplete()) {
       const command = interaction.client.slashCommands.get(
@@ -31,6 +65,23 @@ const event: BotEvent = {
       } catch (err) {
         error(err);
       }
+    } else if (interaction.isButton() && interaction.customId === "publicar") {
+      const originalChannel = interaction.channel;
+      if (originalChannel) {
+        const embed = new EmbedBuilder(interaction.message.embeds[0].toJSON());
+        originalChannel.send({ embeds: [embed] });
+      } else {
+        console.error("Interaction is not in a guild.");
+      }
+
+      const button = interaction.message.components[0]
+        .components[0] as ButtonComponent;
+      const bb = ButtonBuilder.from(button).setDisabled(true);
+      const row = new ActionRowBuilder<ButtonBuilder>().addComponents(bb);
+
+      interaction.update({
+        components: [row],
+      });
     }
   },
 };

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -9,6 +9,8 @@ const event: BotEvent = {
   name: Events.ClientReady,
   once: true,
   execute: async (client: Client) => {
+    client.nextStatus = ["change", 0];
+    client.lastPrice = 0;
     ticker(client);
     mempool(client);
     //await client.updateTicker();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -78,12 +78,57 @@ export const formatDuration = (ms: number) => {
   return parts.join(" ");
 };
 
+export const formatAgo = (timestamp: number) => {
+  const MS_IN_SECOND = 1000;
+  const MS_IN_MINUTE = MS_IN_SECOND * 60;
+  const MS_IN_HOUR = MS_IN_MINUTE * 60;
+  const MS_IN_DAY = MS_IN_HOUR * 24;
+
+  const d = Math.floor(timestamp / MS_IN_DAY);
+  const h = Math.floor((timestamp - MS_IN_DAY * d) / MS_IN_HOUR);
+  const m = Math.floor(
+    (timestamp - MS_IN_DAY * d - MS_IN_HOUR * h) / MS_IN_MINUTE
+  );
+  const s = Math.floor(
+    (timestamp - MS_IN_DAY * d - MS_IN_HOUR * h - MS_IN_MINUTE * m) /
+      MS_IN_SECOND
+  );
+
+  const parts = [];
+
+  if (d > 0) {
+    parts.push(`${d} día${d === 1 ? "" : "s"}`);
+  }
+
+  if (d > 0 || h > 0) {
+    parts.push(`${h} hora${h === 1 ? "" : "s"}`);
+  }
+
+  if (d > 0 || h > 0 || m > 0) {
+    parts.push(`${m} minuto${m === 1 ? "" : "s"}`);
+  }
+
+  parts.push(`${s} segundo${s === 1 ? "" : "s"}`);
+
+  return parts.join(" ");
+};
+
 export const formatDate = (d: Date): string => {
   return d
     .toLocaleString("es-AR", {
       timeZone: "America/Argentina/Buenos_Aires",
     })
     .replace(",", "");
+};
+
+export const formatPrice = (
+  price: number,
+  decimals: boolean = false
+): string => {
+  return price.toLocaleString("es-AR", {
+    minimumFractionDigits: decimals ? 2 : 0,
+    maximumFractionDigits: decimals ? 2 : 0,
+  });
 };
 
 export const formatPercentageChange = (

--- a/src/service/discord/ticker.ts
+++ b/src/service/discord/ticker.ts
@@ -7,7 +7,12 @@ import {
   Role,
 } from "discord.js";
 import watchPrice from "../coinbase/coinbase";
-import { formatPercentageChange, logger } from "../../helpers";
+import {
+  formatDate,
+  formatPercentageChange,
+  formatPrice,
+  logger,
+} from "../../helpers";
 import { Debugger } from "debug";
 
 const log: Debugger = logger.extend("updateTicker");
@@ -15,68 +20,98 @@ const error: Debugger = log.extend("error");
 const debug: Debugger = log.extend("debug");
 
 const ticker = (client: Client) => {
-  client.updateTicker = async (price: number, open24h: number) => {
+  client.updateTicker = async (price?: number, open24h?: number) => {
     const trackLimits = new Collection<string, number>();
 
     try {
-      const nickname = `$${price.toLocaleString("es-AR", {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-      })}`;
+      if (price) {
+        const nickname = `$${formatPrice(price)}`;
 
-      const change = formatPercentageChange(open24h, price);
-      client.user!.setPresence({
-        activities: [
-          {
-            type: ActivityType.Custom,
-            name: "custom", // name is exposed through the API but not shown in the client for ActivityType.Custom
-            state: `Var. diaria: ${change}`,
-          },
-        ],
-        status: "online",
-      });
+        // First time = color Green, otherwhise, check if price is higher or lower
+        let colorOn = "Ticker Green";
+        let colorOff = "Ticker Red";
+        if (client.lastPrice !== null && price < client.lastPrice) {
+          colorOn = "Ticker Red";
+          colorOff = "Ticker Green";
+        }
 
-      // First time = color Green, otherwhise, check if price is higher or lower
-      let colorOn = "Ticker Green";
-      let colorOff = "Ticker Red";
-      if (client.lastPrice !== null && price < client.lastPrice) {
-        colorOn = "Ticker Red";
-        colorOff = "Ticker Green";
+        client.lastPrice = price;
+        debug(`Updating nickname to ${nickname} and role to ${colorOn}`);
+
+        client.guilds.cache.forEach((guild) => {
+          const bot: GuildMember = guild.members.me!;
+
+          if (nickname != bot.nickname) {
+            if (trackLimits.has(guild.id)) {
+              if (trackLimits.get(guild.id)! < new Date().getTime()) {
+                debug("Resetting limit");
+                trackLimits.delete(guild.id);
+              } else {
+                return;
+              }
+            }
+
+            changeNickname(
+              bot,
+              nickname,
+              guild.roles.cache.find((role) => role.name == colorOn),
+              guild.roles.cache.find((role) => role.name == colorOff)
+            ).then((timeToReset) => {
+              if (timeToReset) {
+                error(
+                  "LIMIT on guild %s - Waiting for %d",
+                  guild.id,
+                  timeToReset
+                );
+                trackLimits.set(guild.id, timeToReset + new Date().getTime());
+              }
+            });
+          }
+        });
       }
 
-      client.lastPrice = price;
-      debug(`Updating nickname to ${nickname} and role to ${colorOn}`);
+      if (
+        client.nextStatus[0] == "change" &&
+        client.nextStatus[1] <= Date.now()
+      ) {
+        if (!(open24h && price)) return;
 
-      client.guilds.cache.forEach((guild) => {
-        const bot: GuildMember = guild.members.me!;
+        const change = formatPercentageChange(open24h, price);
+        client.user!.setPresence({
+          activities: [
+            {
+              type: ActivityType.Custom,
+              name: "custom",
+              state: `Var. diaria: ${change}`,
+            },
+          ],
+          status: "online",
+        });
+        debug(
+          `Updating status to daily variation on ${formatDate(new Date())}`
+        );
 
-        if (nickname != bot.nickname) {
-          if (trackLimits.has(guild.id)) {
-            if (trackLimits.get(guild.id)! < new Date().getTime()) {
-              debug("Resetting limit");
-              trackLimits.delete(guild.id);
-            } else {
-              return;
-            }
-          }
+        client.nextStatus = ["fees", Date.now() + 10 * 1000]; // 10s for fees
+      } else if (
+        client.nextStatus[0] == "fees" &&
+        client.nextStatus[1] <= Date.now()
+      ) {
+        if (!client.fees) return;
 
-          changeNickname(
-            bot,
-            nickname,
-            guild.roles.cache.find((role) => role.name == colorOn),
-            guild.roles.cache.find((role) => role.name == colorOff)
-          ).then((timeToReset) => {
-            if (timeToReset) {
-              error(
-                "LIMIT on guild %s - Waiting for %d",
-                guild.id,
-                timeToReset
-              );
-              trackLimits.set(guild.id, timeToReset + new Date().getTime());
-            }
-          });
-        }
-      });
+        client.user!.setPresence({
+          activities: [
+            {
+              type: ActivityType.Custom,
+              name: "fees",
+              state: `sats/vB: ⏬ ${client.fees.low} ↔️ ${client.fees.medium} ⏫ ${client.fees.high}`,
+            },
+          ],
+          status: "online",
+        });
+        debug(`Updating status to fees on ${formatDate(new Date())}`);
+
+        client.nextStatus = ["change", Date.now() + 20 * 1000]; // 20s for change price percentage
+      }
     } catch (err) {
       error(err);
     }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,13 +15,21 @@ declare module "discord.js" {
     slashCommands: Collection<string, SlashCommand>;
     cooldowns: Collection<string, number>;
     lastBlock: Block | null;
-    lastPrice: number | null;
+    lastPrice: number;
     averageBlockTime: number | null;
+    fees: Fees | null;
     updateLastBlock: (block: Block) => void;
-    updateTicker: (price: number, open24h: number) => void;
+    updateTicker: (price?: number, open24h?: number) => void;
+    nextStatus: ["change" | "fees", number];
   }
 }
-
+export interface Fees {
+  economy: number;
+  low: number;
+  medium: number;
+  high: number;
+  timestamp: number;
+}
 export interface BotEvent {
   name: string; // Nombre del evento
   once?: boolean | false; // Por única vez?


### PR DESCRIPTION
### Summary
This PR introduces the `/fees` command, which fetches and displays recommended onchain Bitcoin transaction fees in an ephemeral message. It also includes a button that allows users to share the information publicly in the channel.

### Features:
- **Ephemeral response**: The `/fees` command returns an embed visible only to the user who executed the command.
- **Share button**: Users can click a button to publish the same embed to the current channel.
- **Organized presentation**: Transaction fees are displayed in an easy-to-read embed format with priority levels.
